### PR TITLE
Resourcemanager special chars as default culture

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -369,10 +369,10 @@ abstract class resourceFile {
             return this.resources[language][resKey];
         }
 
-        // If no entry could be found in the currently active langugae, try the default language
-        if (this.resources.hasOwnProperty('${defaultCulture}') && this.resources.${defaultCulture}.hasOwnProperty(resKey)) {
+        // If no entry could be found in the currently active language, try the default language
+        if (this.resources.hasOwnProperty('${defaultCulture}') && this.resources['${defaultCulture}'].hasOwnProperty(resKey)) {
             console.log(\`No text resource in the language "\${language}" with the key "\${resKey}".\`);
-            return this.resources.${defaultCulture}[resKey];
+            return this.resources['${defaultCulture}'][resKey];
         }
 
         // If there is still no resource found output a warning and return the key.


### PR DESCRIPTION
Currently if you put something like en-US as the default culture in the typescript file would fail to generate property because "this.resources.en-US.hasOwnProperty" is considered invalid and will throw an error.